### PR TITLE
save ghoul's position for 1.5 DLC

### DIFF
--- a/Source/JobDriver_DraftToPosition.cs
+++ b/Source/JobDriver_DraftToPosition.cs
@@ -13,7 +13,8 @@ namespace DefensivePositions {
 		}
 
 		protected override IEnumerable<Toil> MakeNewToils() {
-			AddFailCondition(() => !pawn.IsColonistPlayerControlled || pawn.Downed || pawn.drafter == null);
+			AddFailCondition(() => !(pawn.IsColonistPlayerControlled || pawn.IsColonyMutantPlayerControlled)
+								  || pawn.Downed || pawn.drafter == null);
 			var toil = new Toil {
 				initAction = () => {
 					pawn.drafter.Drafted = true;


### PR DESCRIPTION
As reported by many players, the ghouls in 1.5 DLC cannot move to their saved defensive position, this can be solved by considering `pawn.IsColonyMutantPlayerControlled` in AddFailCondition